### PR TITLE
Check chunk structure references exist before fetching them

### DIFF
--- a/src/main/java/com/telepathicgrunt/repurposedstructures/mixin/features/NoBasaltColumnsInStructuresMixin.java
+++ b/src/main/java/com/telepathicgrunt/repurposedstructures/mixin/features/NoBasaltColumnsInStructuresMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.levelgen.feature.BasaltColumnsFeature;
 import net.minecraft.world.level.levelgen.feature.StructureFeature;
 import net.minecraft.world.level.levelgen.structure.StructureStart;
@@ -26,6 +27,10 @@ public class NoBasaltColumnsInStructuresMixin {
     )
     private static void repurposedstructures_noBasaltColumnsInStructures(LevelAccessor levelAccessor, int seaLevel, BlockPos.MutableBlockPos mutableBlockPos, CallbackInfoReturnable<Boolean> cir) {
         SectionPos sectionPos = SectionPos.of(mutableBlockPos);
+        if (!levelAccessor.getChunk(sectionPos.x(), sectionPos.z()).getStatus().isOrAfter(ChunkStatus.STRUCTURE_REFERENCES)) {
+            cir.setReturnValue(false);
+            return;
+        }
         for (StructureFeature<?> structure : RSStructureTagMap.REVERSED_TAGGED_STRUCTURES.get(RSStructureTagMap.STRUCTURE_TAGS.NO_DELTAS)) {
             Optional<? extends StructureStart<?>> structureStart = ((WorldGenLevel)levelAccessor).startsForFeature(sectionPos, structure).findAny();
             boolean checkCenterOnly = RSStructureTagMap.TAGGED_STRUCTURES.get(structure).contains(RSStructureTagMap.STRUCTURE_TAGS.DELTA_CHECK_CENTER_PIECE);


### PR DESCRIPTION
Basalt columns may attempt to be placed far enough away from the chunk the feature is in that structure references are not available for the chunk they're placed in. For some reason, MC decides the best course of action when attempting to get structure references for a chunk that's too young is to throw a fatal RTE.

I've patched this, although there may be a smarter way to go about this.